### PR TITLE
Set `TraceableExchangeRateHostClient` as last decorator

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -28,7 +28,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         $services
             ->set('benjaminmal.exchangerate_host_bundle.traceable_client')
             ->class(TraceableExchangeRateHostClient::class)
-            ->decorate('benjaminmal.exchangerate_host_bundle.client')
+            ->decorate('benjaminmal.exchangerate_host_bundle.client', priority: -128)
             ->args([
                 service('.inner'),
                 service('debug.stopwatch'),

--- a/src/ExchangeRateHostBundle.php
+++ b/src/ExchangeRateHostBundle.php
@@ -67,7 +67,7 @@ final class ExchangeRateHostBundle extends AbstractBundle implements CompilerPas
             $services
                 ->set('benjaminmal.exchangerate_host_bundle.cacheable_client')
                 ->class(CacheableExchangeRateHostClient::class)
-                ->decorate('benjaminmal.exchangerate_host_bundle.client')
+                ->decorate('benjaminmal.exchangerate_host_bundle.client', priority: 128)
                 ->args([
                     service('.inner'),
                     service('benjaminmal.exchangerate_host_bundle.cache_pool'),

--- a/tests/BundleTest.php
+++ b/tests/BundleTest.php
@@ -75,10 +75,10 @@ class BundleTest extends KernelTestCase
     public static function serviceProvider(): array
     {
         return [
-            [ExchangeRateHostClientInterface::class, CacheableExchangeRateHostClient::class, true],
-            ['benjaminmal.exchangerate_host_bundle.client', CacheableExchangeRateHostClient::class, true],
-            ['benjaminmal.exchangerate_host_bundle.cacheable_client', CacheableExchangeRateHostClient::class, true],
+            [ExchangeRateHostClientInterface::class, TraceableExchangeRateHostClient::class, true],
+            ['benjaminmal.exchangerate_host_bundle.client', TraceableExchangeRateHostClient::class, true],
             ['benjaminmal.exchangerate_host_bundle.traceable_client', TraceableExchangeRateHostClient::class, true],
+            ['benjaminmal.exchangerate_host_bundle.cacheable_client', CacheableExchangeRateHostClient::class, true],
             ['benjaminmal.exchangerate_host_bundle.base_client', ExchangeRateHostClient::class, true],
             ['benjaminmal.exchangerate_host_bundle.http_client', ClientInterface::class, true],
             ['benjaminmal.exchangerate_host_bundle.uri_factory', UriFactoryInterface::class, true],
@@ -86,8 +86,8 @@ class BundleTest extends KernelTestCase
             ['benjaminmal.exchangerate_host_bundle.cache_pool', CacheInterface::class, true],
 
             // Should not exist
-            [ExchangeRateHostClientInterface::class, TraceableExchangeRateHostClient::class, false],
-            ['benjaminmal.exchangerate_host_bundle.client', TraceableExchangeRateHostClient::class, false],
+            [ExchangeRateHostClientInterface::class, CacheableExchangeRateHostClient::class, false],
+            ['benjaminmal.exchangerate_host_bundle.client', CacheableExchangeRateHostClient::class, false],
             [ExchangeRateHostClientInterface::class, ExchangeRateHostClient::class, false],
             ['benjaminmal.exchangerate_host_bundle.client', ExchangeRateHostClient::class, false],
         ];


### PR DESCRIPTION
So we can see performance in webprofiler even if the cache handle the request.